### PR TITLE
Removed cost_center tag

### DIFF
--- a/tag-policy.tf
+++ b/tag-policy.tf
@@ -60,7 +60,6 @@ resource "azurerm_policy_assignment" "tags" {
     "project",
     "subscription_id",
     "business_unit", 
-    "cost_center",
     "sre_team",
     "resource_group_type",
     "subscription_type",


### PR DESCRIPTION
The cost_center tag is no longer mandatory on resources.
After a discussion with Charles Kaminski he only wants the cost_center tag on the subscription.

This change removes the cost_center tag from the Azure Policy.