### PR TITLE
Update main.tf

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -2,6 +2,10 @@ locals {
   resource_group_name = "${var.names.resource_group_type}-${var.names.product_name}-${var.names.environment}-${var.names.location}"
 }
 
+provider "azurerm" {
+  features {}
+}
+
 resource "azurerm_resource_group" "rg" {
   name     = local.resource_group_name
   location = var.location


### PR DESCRIPTION
The azurerm 2.0.0 provider now requires features to be defined, even if it's an empty list. Without it this example doesn't work with 2.0.0+