### PR TITLE
Enable more than 1 resource group

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Naming for this resource is as follows, based on published RBA naming convention
 | location | Azure Region | `string` | n/a | yes |
 | names | Names to be applied to resources (inclusive) | <pre>object({<br>                  environment         = string<br>                  location            = string<br>                  market              = string<br>                  product_name        = string<br>                  resource_group_type = string<br>                })</pre> | n/a | yes |
 | tags | Tags to be applied to resources (inclusive) | `map(string)` | n/a | yes |
+| unique_name | If true, the resource group name will be appended with 5 random integers | `bool` | false | no |
 
 ## Outputs
 

--- a/main.tf
+++ b/main.tf
@@ -1,9 +1,17 @@
 locals {
-  resource_group_name = "${var.names.resource_group_type}-${var.names.product_name}-${var.names.environment}-${var.names.location}"
+
+  standard_name       = "${var.names.resource_group_type}-${var.names.product_name}-${var.names.environment}-${var.names.location}"
+  unique_name         = "${local.standard_name}-${random_integer.suffix.result}"
+  resource_group_name = var.unique_name ? local.unique_name  : local.standard_name
+}
+
+resource "random_integer" "suffix" {
+  min = 10000
+  max = 99999
 }
 
 resource "azurerm_resource_group" "rg" {
-  name     = local.resource_group_name
-  location = var.location
-  tags     = var.tags
+  name          = local.resource_group_name
+  location      = var.location
+  tags          = var.tags
 }

--- a/variables.tf
+++ b/variables.tf
@@ -8,13 +8,19 @@ variable "tags" {
   type        = map(string)
 }
 
+variable "unique_name" {
+  description = "If true, the resource group name will be appended with 5 random integers"
+  type        = bool
+  default     = false
+}
+
 variable "names" {
   description = "Names to be applied to resources (inclusive)"
   type        = object({
-                  environment         = string
-                  location            = string
-                  market              = string
-                  product_name        = string
-                  resource_group_type = string
-                })
+    environment         = string
+    location            = string
+    market              = string
+    product_name        = string
+    resource_group_type = string
+  })
 }


### PR DESCRIPTION
Developers need the ability to have more than one resource group in dev based on resource_group_type, product_name, environment, and location.  RG-based blue-green deployments need this capability as well.

The PR uses an optional parameter so as not to disrupt any existing flows.