### PR TITLE
Make the creation of the random_integer resource conditional upon setting var.unique_name to true

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Naming for this resource is as follows, based on published RBA naming convention
 | Name | Version |
 |------|---------|
 | azurerm | >= 2.0.0 |
-| random | n/a |
+| random | >= 2.0.0 |
 
 ## Inputs
 

--- a/main.tf
+++ b/main.tf
@@ -1,17 +1,16 @@
 locals {
-
-  standard_name       = "${var.names.resource_group_type}-${var.names.product_name}-${var.names.environment}-${var.names.location}"
-  unique_name         = "${local.standard_name}-${random_integer.suffix.result}"
-  resource_group_name = var.unique_name ? local.unique_name  : local.standard_name
+  resource_group_name = "${var.names.resource_group_type}-${var.names.product_name}-${var.names.environment}-${var.names.location}"
 }
 
 resource "random_integer" "suffix" {
+  count = var.unique_name ? 1 : 0
+
   min = 10000
   max = 99999
 }
 
 resource "azurerm_resource_group" "rg" {
-  name          = local.resource_group_name
-  location      = var.location
-  tags          = var.tags
+  name     = var.unique_name ? "${local.resource_group_name}-${random_integer.suffix[0].result}" : local.resource_group_name
+  location = var.location
+  tags     = var.tags
 }

--- a/versions.tf
+++ b/versions.tf
@@ -1,7 +1,14 @@
 terraform {
-  required_version = ">= 0.12.10"
+  required_version = ">= 0.13.0"
 
   required_providers {
-    azurerm = ">= 2.0.0"
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = ">= 2.0.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 2.0.0"
+    }
   }
 }


### PR DESCRIPTION
Fixes #6.

Also fixes the following three items:

- Upgrading the module from v1.0.0 to v1.1.0 sometimes caused an unexplained diff in downstream resources. An unintended side effect of this refactor is that this weird diff doesn't occur anymore.
- Updates the provider dependency syntax to TF 0.13+ standards with the `source` argument.
- Explicitly declares a dependency on the random provider.

Due to second point above, when this is released, recommend incrementing the major version (e.g. 1.0.0 -> 2.0.0) as the new provider syntax drops support for TF 0.12.